### PR TITLE
Add x-checker-data

### DIFF
--- a/dev.linwood.butterfly.json
+++ b/dev.linwood.butterfly.json
@@ -46,8 +46,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz",
-                    "sha256": "3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d"
+                    "url": "https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.20.5/libsecret-0.20.5.tar.gz",
+                    "sha256": "b33b9542222ea8866f6ff2d31c0ad373877c2277db546ca00cc7fdda9cbab1c3",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13150,
+                        "url-template": "https://gitlab.gnome.org/GNOME/libsecret/-/archive/$version/libsecret-$version.tar.gz"
+                    }
                 }
             ]
         },
@@ -69,7 +74,13 @@
                     "type": "archive",
                     "url": "https://github.com/LinwoodCloud/Butterfly/releases/download/v1.4.4/linwood-butterfly-linux-alternative.tar.gz",
                     "sha256": "db90c26b0feecbea787f0da376fa5f856d3b64a52c02a59308c76c011865c229",
-                    "dest": "FlutterApp"
+                    "dest": "FlutterApp",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/LinwoodCloud/Butterfly/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name==\"linwood-butterfly-linux-alternative.tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
´This PR adds x-checker-data as discussed in #5 . Please note, that the beta repo and Flathub in general is not for nightlies.

f-e-d-c runs once per hour. If there is a new version, a PR will be created.

Butterfly doesn't wok with the newest version of libjsoncpp., so I haven't add x-checker-data. You should fix that.