### PR TITLE
Add socket and talk-name options to JSON config

### DIFF
--- a/dev.linwood.butterfly.json
+++ b/dev.linwood.butterfly.json
@@ -11,6 +11,8 @@
         "--socket=wayland",
         "--device=dri",
         "--share=network",
+        "--talk-name=org.freedesktop.secrets",
+        "--system-talk-name=org.freedesktop.NetworkManager",
         "--filesystem=xdg-documents/Linwood/Butterfly:create"
     ],
     "modules": [


### PR DESCRIPTION
This fixes webdav problems not working on the latest stable with the flatpak