### PR TITLE
Update Butterfly to 2.6.0-beta.4

### DIFF
--- a/dev.linwood.butterfly.json
+++ b/dev.linwood.butterfly.json
@@ -51,8 +51,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.3/linwood-butterfly-linux-x86_64.tar.gz",
-                    "sha256": "773391f52d2f93c5ebdab2d3c4d700046ed540d36ea398656eaeeb7a1167a6e1",
+                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.4/linwood-butterfly-linux-x86_64.tar.gz",
+                    "sha256": "0f4d7343ea610736cc8de94c56e3397afae417c1a5be6305ab26b3f4d829e6b1",
                     "dest": "FlutterApp",
                     "only-arches": ["x86_64"],
                     "x-checker-data": {
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.3/linwood-butterfly-linux-arm64.tar.gz",
-                    "sha256": "e01d3cbc1a59c7b8d949c4ddd146a2dd4fb26af6b3093d9f682f9e9f5c789e0a",
+                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.4/linwood-butterfly-linux-arm64.tar.gz",
+                    "sha256": "b60fd1019f5235d7584b188fd24eeac30c579bf296b754631d3db4fd2888c3e2",
                     "dest": "FlutterApp",
                     "only-arches": ["aarch64"],
                     "x-checker-data": {


### PR DESCRIPTION
Automated update for Butterfly 2.6.0-beta.4.

Release:
https://github.com/LinwoodDev/Butterfly/releases/tag/v2.6.0-beta.4

The download URLs and SHA256 checksums for the x86_64 and arm64
Linux archives were generated from the published release assets.
