### PR TITLE
Update Butterfly to 2.6.0-beta.6

### DIFF
--- a/dev.linwood.butterfly.json
+++ b/dev.linwood.butterfly.json
@@ -51,8 +51,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.5/linwood-butterfly-linux-x86_64.tar.gz",
-                    "sha256": "1af718f64bdecb78626747f0709da7f5af9edbf49a90258a90320260c24b0e14",
+                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.6/linwood-butterfly-linux-x86_64.tar.gz",
+                    "sha256": "93eb9a63727c15029c90a4dadec5e3735e413a0807bf10d4197dec79a86ee1eb",
                     "dest": "FlutterApp",
                     "only-arches": ["x86_64"],
                     "x-checker-data": {
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.5/linwood-butterfly-linux-arm64.tar.gz",
-                    "sha256": "71eaa6ebb7a72745f3145f5178273455ba30ea0ec6ee3b3f8634f71e707aa0a0",
+                    "url": "https://github.com/LinwoodDev/Butterfly/releases/download/v2.6.0-beta.6/linwood-butterfly-linux-arm64.tar.gz",
+                    "sha256": "57dbbcbbdeec2f7211de7d8f56d1fc8b1e4d858cac4cee6ad50aef2be4b3c5c8",
                     "dest": "FlutterApp",
                     "only-arches": ["aarch64"],
                     "x-checker-data": {


### PR DESCRIPTION
Automated update for Butterfly 2.6.0-beta.6.

Release:
https://github.com/LinwoodDev/Butterfly/releases/tag/v2.6.0-beta.6

The download URLs and SHA256 checksums for the x86_64 and arm64
Linux archives were generated from the published release assets.
